### PR TITLE
Adds user creation support to Ubuntu 16.04 only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem 'net-ssh'
 group :test do
   gem 'faker'
   gem 'docker-api'
+  gem 'openssl'
+  gem 'sshkey'
 end
 
 # Specify your gem's dependencies in sshpm.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,11 @@
 source 'https://rubygems.org'
 
 gem 'dry-struct'
+gem 'net-ssh'
 
 group :test do
   gem 'faker'
+  gem 'docker-api'
 end
 
 # Specify your gem's dependencies in sshpm.gemspec

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or install it yourself as:
 SSHPM.manage(['host1', 'host2', 'host3']) do
   add_user do
     name 'user1_name'
-    public_key 'OnotaXaeouaenthaeu'
+    password 'OnotaXaeouaenthaeu'
     sudo true
   end
 
@@ -37,7 +37,7 @@ SSHPM.manage(['host1', 'host2', 'host3']) do
   # in this case, the user is not sudo
   add_user do
     name 'user3_name'
-    public_key 'OnotaXaeouaenthaeu'
+    password 'OnotaXaeouaenthaeu'
   end
 end
 ```

--- a/lib/sshpm.rb
+++ b/lib/sshpm.rb
@@ -1,18 +1,18 @@
+require "net/ssh"
 require "sshpm/version"
+require "sshpm/types"
 require "sshpm/manager"
+require "sshpm/entities"
 
 module SSHPM
   def self.manage(hosts = [], &block)
     hosts = [hosts] unless hosts.is_a? Array
+    hosts = hosts.map { |host| Host.new host }
 
-    unless hosts.all? { |host| [String, Symbol].include? host.class }
-      raise TypeError('hosts must be either String or Symbols')
-    end
-
-    hosts.map(&:to_s).uniq.map do |host|
+    hosts.map do |host|
       manager = Manager.new(host)
       manager.instance_eval(&block)
-      manager.tasks
+      manager.run_tasks
     end
   end
 end

--- a/lib/sshpm/entities.rb
+++ b/lib/sshpm/entities.rb
@@ -1,0 +1,16 @@
+require 'dry-struct'
+
+module Types
+  include Dry::Types.module
+end
+
+module SSHPM
+  class Host < Dry::Struct
+    constructor_type :strict_with_defaults
+
+    attribute :hostname, Types::Strict::String
+    attribute :port, Types::Strict::String
+    attribute :user, Types::Strict::String.default('root')
+    attribute :password, Types::Strict::String
+  end
+end

--- a/lib/sshpm/entities.rb
+++ b/lib/sshpm/entities.rb
@@ -11,6 +11,7 @@ module SSHPM
     attribute :hostname, Types::Strict::String
     attribute :port, Types::Strict::String
     attribute :user, Types::Strict::String.default('root')
-    attribute :password, Types::Strict::String
+    attribute :password, Types::Strict::String.default("")
+    attribute :identity, Types::Strict::String.default("")
   end
 end

--- a/lib/sshpm/manager.rb
+++ b/lib/sshpm/manager.rb
@@ -3,9 +3,15 @@ require 'sshpm/tasks'
 class SSHPM::Manager
   attr_accessor :host, :tasks
 
-  def initialize(host='localhost')
+  def initialize(host=nil)
     @host = host
     @tasks = []
+  end
+
+  def run_tasks
+    tasks.map do |task|
+      task.run_on(@host)
+    end
   end
 
   def add_user(&block)

--- a/lib/sshpm/tasks.rb
+++ b/lib/sshpm/tasks.rb
@@ -1,20 +1,3 @@
-require 'dry-struct'
 require 'sshpm/tasks/builder'
-
-module Types
-  include Dry::Types.module
-end
-
-module SSHPM::Tasks
-  class AddUser < Dry::Struct
-    constructor_type :strict_with_defaults
-
-    attribute :name, Types::Strict::String
-    attribute :public_key, Types::Strict::String
-    attribute :sudo, Types::Strict::Bool.default(false)
-  end
-
-  class RemoveUser < Dry::Struct
-    attribute :name, Types::Strict::String
-  end
-end
+require 'sshpm/tasks/add_user'
+require 'sshpm/tasks/remove_user'

--- a/lib/sshpm/tasks/add_user.rb
+++ b/lib/sshpm/tasks/add_user.rb
@@ -3,7 +3,8 @@ module SSHPM::Tasks
     constructor_type :strict_with_defaults
 
     attribute :name, Types::Strict::String
-    attribute :password, Types::Strict::String
+    attribute :password, Types::Strict::String.default("")
+    attribute :public_key, Types::Strict::String.default("")
     attribute :sudo, Types::Strict::Bool.default(false)
 
     def run_on(host)
@@ -14,7 +15,21 @@ module SSHPM::Tasks
       options = { password: host.password, port: host.port }
       Net::SSH.start(host.hostname, host.user, options) do |ssh|
         ssh.exec! "useradd -m #{name}"
-        ssh.exec! "echo \"#{name}:#{password}\" | chpasswd"
+
+        if password != ""
+          ssh.exec! "echo \"#{name}:#{password}\" | chpasswd"
+        end
+
+        if public_key != ""
+          ssh_dir = "/home/#{name}/.ssh"
+          auth_keys_file = "#{ssh_dir}/authorized_keys"
+
+          ssh.exec! "mkdir -p #{ssh_dir}"
+          ssh.exec! "chmod 700 #{ssh_dir}"
+          ssh.exec! "echo \"#{public_key}\" >> #{auth_keys_file}"
+          ssh.exec! "chmod 600 #{auth_keys_file}"
+          ssh.exec! "chown -R #{name}:#{name} #{ssh_dir}"
+        end
       end
     end
   end

--- a/lib/sshpm/tasks/add_user.rb
+++ b/lib/sshpm/tasks/add_user.rb
@@ -1,0 +1,21 @@
+module SSHPM::Tasks
+  class AddUser < Dry::Struct
+    constructor_type :strict_with_defaults
+
+    attribute :name, Types::Strict::String
+    attribute :password, Types::Strict::String
+    attribute :sudo, Types::Strict::Bool.default(false)
+
+    def run_on(host)
+      unless host.is_a? SSHPM::Host
+        raise TypeError("host #{host} is not a #{SSHPM::Host}")
+      end
+
+      options = { password: host.password, port: host.port }
+      Net::SSH.start(host.hostname, host.user, options) do |ssh|
+        ssh.exec! "useradd -m #{name}"
+        ssh.exec! "echo \"#{name}:#{password}\" | chpasswd"
+      end
+    end
+  end
+end

--- a/lib/sshpm/tasks/remove_user.rb
+++ b/lib/sshpm/tasks/remove_user.rb
@@ -1,0 +1,5 @@
+module SSHPM::Tasks
+  class RemoveUser < Dry::Struct
+    attribute :name, Types::Strict::String
+  end
+end

--- a/lib/sshpm/types.rb
+++ b/lib/sshpm/types.rb
@@ -1,0 +1,5 @@
+require 'dry-struct'
+
+module Types
+  include Dry::Types.module
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "sshpm"
+require "faker"

--- a/spec/sshpm/manager_spec.rb
+++ b/spec/sshpm/manager_spec.rb
@@ -1,13 +1,12 @@
 require 'spec_helper'
-require 'faker'
 
 describe SSHPM::Manager do
   it "Newly created manager has no tasks" do
     expect(SSHPM::Manager.new.tasks).to eq([])
   end
 
-  it "If not specified, host must be equal to 'localhost'" do
-    expect(SSHPM::Manager.new.host).to eq('localhost')
+  it "If not specified, host must be nil" do
+    expect(SSHPM::Manager.new.host).to eq(nil)
   end
   
   context "add_user" do
@@ -19,8 +18,8 @@ describe SSHPM::Manager do
 
       (1..10).each do |index|
         @manager.add_user do
-          name Faker::Name.name
-          public_key Faker::Crypto.sha256
+          name Faker::Internet.user_name
+          password Faker::Internet.password
         end
 
         expect(@manager.tasks.size).to eq(index)
@@ -47,8 +46,8 @@ describe SSHPM::Manager do
 
       (1..10).each do |index|
         @manager.remove_user do
-          name Faker::Name.name
-          public_key Faker::Crypto.sha256
+          name Faker::Internet.user_name
+          password Faker::Internet.password
         end
 
         expect(@manager.tasks.size).to eq(index)

--- a/spec/sshpm_spec.rb
+++ b/spec/sshpm_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 require "docker"
 require "net/ssh"
+require "sshkey"
 
 describe SSHPM do
   it "has a version number" do
@@ -36,7 +37,14 @@ describe SSHPM do
       it "is successfull if password is correct" do
         @test_servers.each do |server|
           expect do
-            Net::SSH.start('localhost', 'root', password: 'test_password', port: server[:port], non_interactive: true, paranoid: false)
+            opts = {
+              password: 'test_password',
+              port: server[:port],
+              non_interactive: true,
+              paranoid: false
+            }
+
+            Net::SSH.start('localhost', 'root', opts)
           end.to_not raise_error
         end
       end
@@ -44,41 +52,100 @@ describe SSHPM do
       it "is unsuccessfull if password is incorrect" do
         @test_servers.each do |server|
           expect do
-            Net::SSH.start('localhost', 'root', password: 'test_passwrd', port: server[:port], non_interactive: true, paranoid: false)
+            opts = {
+              password: 'test_passwrd',
+              port: server[:port],
+              non_interactive: true,
+              paranoid: false
+            }
+
+            Net::SSH.start('localhost', 'root', opts)
           end.to raise_error(Net::SSH::AuthenticationFailed)
         end
       end
     end
 
     context "Add a new user" do
-      before :all do
-        @user = user = {
-          username: Faker::Internet.user_name,
-          password: Faker::Internet.password
-        }
-
-        @hosts = @test_servers.map do |server|
-          {
-            hostname: 'localhost',
-            port: server[:port], 
-            user: 'root',
-            password: 'test_password'
+      context "with only password" do
+        before :all do
+          @user = user = {
+            username: Faker::Internet.user_name,
+            password: Faker::Internet.password
           }
+
+          @hosts = @test_servers.map do |server|
+            {
+              hostname: 'localhost',
+              port: server[:port], 
+              user: 'root',
+              password: 'test_password'
+            }
+          end
+
+          SSHPM.manage(@hosts) do
+            add_user do
+              name user[:username]
+              password user[:password]
+            end
+          end
         end
 
-        SSHPM.manage(@hosts) do
-          add_user do
-            name user[:username]
-            password user[:password]
+        it "login successfully as the new user on all test servers" do
+          @test_servers.each do |server|
+            expect do
+              opts = {
+                password: @user[:password],
+                port: server[:port],
+                non_interactive: true,
+                paranoid: false
+              }
+              
+              Net::SSH.start('localhost', @user[:username], opts)
+            end.to_not raise_error
           end
         end
       end
 
-      it "login successfully as the new user on all test servers" do
-        @test_servers.each do |server|
-          expect do
-            Net::SSH.start('localhost', @user[:username], password: @user[:password], port: server[:port], non_interactive: true, paranoid: false)
-          end.to_not raise_error
+      context "with only pub/private keys" do
+        before :all do
+          @rsa_key = SSHKey.generate
+          @user = user = {
+            username: Faker::Internet.user_name,
+            public_key: @rsa_key.ssh_public_key
+          }
+
+          @hosts = @test_servers.map do |server|
+            {
+              hostname: 'localhost',
+              port: server[:port], 
+              user: 'root',
+              password: 'test_password'
+            }
+          end
+
+          SSHPM.manage(@hosts) do
+            add_user do
+              name user[:username]
+              public_key user[:public_key]
+            end
+          end
+        end
+
+        it "login successfully as the new user on all test servers" do
+          @test_servers.each do |server|
+            expect do
+              opts = {
+                keys: [],
+                key_data: [@rsa_key.private_key],
+                keys_only: true,
+                port: server[:port],
+                non_interactive: true,
+                paranoid: false
+              }
+
+              Net::SSH.start('localhost', @user[:username], opts)
+            end.to_not raise_error
+          end
         end
       end
     end

--- a/spec/sshpm_spec.rb
+++ b/spec/sshpm_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "docker"
 
 describe SSHPM do
   it "has a version number" do

--- a/spec/sshpm_spec.rb
+++ b/spec/sshpm_spec.rb
@@ -49,5 +49,38 @@ describe SSHPM do
         end
       end
     end
+
+    context "Add a new user" do
+      before :all do
+        @user = user = {
+          username: Faker::Internet.user_name,
+          password: Faker::Internet.password
+        }
+
+        @hosts = @test_servers.map do |server|
+          {
+            hostname: 'localhost',
+            port: server[:port], 
+            user: 'root',
+            password: 'test_password'
+          }
+        end
+
+        SSHPM.manage(@hosts) do
+          add_user do
+            name user[:username]
+            password user[:password]
+          end
+        end
+      end
+
+      it "login successfully as the new user on all test servers" do
+        @test_servers.each do |server|
+          expect do
+            Net::SSH.start('localhost', @user[:username], password: @user[:password], port: server[:port], non_interactive: true, paranoid: false)
+          end.to_not raise_error
+        end
+      end
+    end
   end
 end

--- a/spec/sshpm_spec.rb
+++ b/spec/sshpm_spec.rb
@@ -104,6 +104,21 @@ describe SSHPM do
             end.to_not raise_error
           end
         end
+
+        it "login fails if password is wrong" do
+          @test_servers.each do |server|
+            expect do
+              opts = {
+                password: Faker::Internet.password,
+                port: server[:port],
+                non_interactive: true,
+                paranoid: false
+              }
+              
+              Net::SSH.start('localhost', @user[:username], opts)
+            end.to raise_error(Net::SSH::AuthenticationFailed)
+          end
+        end
       end
 
       context "with only pub/private keys" do
@@ -145,6 +160,119 @@ describe SSHPM do
 
               Net::SSH.start('localhost', @user[:username], opts)
             end.to_not raise_error
+          end
+        end
+
+        it "login fails if private_key is wrong" do
+          @test_servers.each do |server|
+            expect do
+              opts = {
+                keys: [],
+                key_data: [SSHKey.generate.private_key],
+                keys_only: true,
+                port: server[:port],
+                non_interactive: true,
+                paranoid: false
+              }
+
+              Net::SSH.start('localhost', @user[:username], opts)
+            end.to raise_error(Net::SSH::AuthenticationFailed)
+          end
+        end
+      end
+
+      context "with both password and pub/private keys" do
+        before :all do
+          @rsa_key = SSHKey.generate
+          @user = user = {
+            username: Faker::Internet.user_name,
+            password: Faker::Internet.password,
+            public_key: @rsa_key.ssh_public_key
+          }
+
+          @hosts = @test_servers.map do |server|
+            {
+              hostname: 'localhost',
+              port: server[:port], 
+              user: 'root',
+              password: 'test_password'
+            }
+          end
+
+          SSHPM.manage(@hosts) do
+            add_user do
+              name user[:username]
+              password user[:password]
+              public_key user[:public_key]
+            end
+          end
+        end
+
+        context "login successfully as the new user on all test servers" do
+          it "using identity file" do
+            @test_servers.each do |server|
+              expect do
+                opts = {
+                  keys: [],
+                  key_data: [@rsa_key.private_key],
+                  keys_only: true,
+                  port: server[:port],
+                  non_interactive: true,
+                  paranoid: false
+                }
+
+                Net::SSH.start('localhost', @user[:username], opts)
+              end.to_not raise_error
+            end
+          end
+
+          it "using password" do
+            @test_servers.each do |server|
+              expect do
+                opts = {
+                  password: @user[:password],
+                  port: server[:port],
+                  non_interactive: true,
+                  paranoid: false
+                }
+
+                Net::SSH.start('localhost', @user[:username], opts)
+              end.to_not raise_error
+            end
+          end
+        end
+
+        context "login fails if password or private key is wrong" do
+          it "using identity file" do
+            @test_servers.each do |server|
+              expect do
+                opts = {
+                  keys: [],
+                  key_data: [SSHKey.generate.private_key],
+                  keys_only: true,
+                  port: server[:port],
+                  non_interactive: true,
+                  paranoid: false
+                }
+
+                Net::SSH.start('localhost', @user[:username], opts)
+              end.to raise_error(Net::SSH::AuthenticationFailed)
+            end
+          end
+
+          it "using password" do
+            @test_servers.each do |server|
+              expect do
+                opts = {
+                  password: Faker::Internet.password,
+                  port: server[:port],
+                  non_interactive: true,
+                  paranoid: false
+                }
+
+                Net::SSH.start('localhost', @user[:username], opts)
+              end.to raise_error(Net::SSH::AuthenticationFailed)
+            end
           end
         end
       end

--- a/spec/sshpm_spec.rb
+++ b/spec/sshpm_spec.rb
@@ -1,8 +1,53 @@
 require "spec_helper"
 require "docker"
+require "net/ssh"
 
 describe SSHPM do
   it "has a version number" do
     expect(SSHPM::VERSION).not_to be nil
+  end
+
+  context "Docker test servers" do
+    before :all do
+      platforms = ['ubuntu-1604']
+
+      @test_servers = platforms.map do |platform|
+        container = Docker::Container.create(
+          'Image' => "sshpm-test-server:#{platform}",
+          'ExposedPorts' => { '22/tcp' => {} },
+          'HostConfig' => {
+            'PortBindings' => { '22/tcp' => [{}] }
+          }
+        ).start
+
+        port = container.json["NetworkSettings"]["Ports"]["22/tcp"].first["HostPort"]
+
+        { container: container, port: port }
+      end
+    end
+
+    after :all do
+      @test_servers.each do |server|
+        server[:container].delete(force: true)
+      end
+    end
+
+    context "Login as root" do
+      it "is successfull if password is correct" do
+        @test_servers.each do |server|
+          expect do
+            Net::SSH.start('localhost', 'root', password: 'test_password', port: server[:port], non_interactive: true, paranoid: false)
+          end.to_not raise_error
+        end
+      end
+
+      it "is unsuccessfull if password is incorrect" do
+        @test_servers.each do |server|
+          expect do
+            Net::SSH.start('localhost', 'root', password: 'test_passwrd', port: server[:port], non_interactive: true, paranoid: false)
+          end.to raise_error(Net::SSH::AuthenticationFailed)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Implements user addition functionality, this PR aims to fullfill the following goals:

- [x] Adds user with password only
- [x] Adds user with identity file only
- [x] Adds user with both password and identity file
- [x] When user is added, also create a home folder

This PR focuses on Ubuntu 16.04 as for now, new PRs must be submitted to support other systems