### PR TITLE
Includes Ubuntu versions among test target systems

### DIFF
--- a/lib/sshpm/tasks/add_user.rb
+++ b/lib/sshpm/tasks/add_user.rb
@@ -12,7 +12,12 @@ module SSHPM::Tasks
         raise TypeError("host #{host} is not a #{SSHPM::Host}")
       end
 
-      options = { password: host.password, port: host.port }
+      options = {
+        password: host.password,
+        port: host.port,
+        paranoid: false
+      }
+
       Net::SSH.start(host.hostname, host.user, options) do |ssh|
         ssh.exec! "useradd -m #{name}"
 

--- a/spec/sshpm_spec.rb
+++ b/spec/sshpm_spec.rb
@@ -13,6 +13,8 @@ describe SSHPM do
       platforms = [
         'ubuntu-1404',
         'ubuntu-1604',
+        'ubuntu-1610',
+        'ubuntu-1704',
       ]
 
       @test_servers = platforms.map do |platform|

--- a/spec/sshpm_spec.rb
+++ b/spec/sshpm_spec.rb
@@ -10,7 +10,10 @@ describe SSHPM do
 
   context "Docker test servers" do
     before :all do
-      platforms = ['ubuntu-1604']
+      platforms = [
+        'ubuntu-1404',
+        'ubuntu-1604',
+      ]
 
       @test_servers = platforms.map do |platform|
         container = Docker::Container.create(
@@ -99,7 +102,7 @@ describe SSHPM do
                 non_interactive: true,
                 paranoid: false
               }
-              
+
               Net::SSH.start('localhost', @user[:username], opts)
             end.to_not raise_error
           end


### PR DESCRIPTION
This PR intends to include the following test target systems as Docker containers, to solve part of issue #6:

- [x] Ubuntu 14.04
- [x] Ubuntu 16.04
- [x] Ubuntu 16.10
- [x] Ubuntu 17.04

This is not the only repository changed, these systems are configured in the following repository
https://github.com/ssh-pm/ssh-test-servers