### PR TITLE
Adds user removal feature

### DIFF
--- a/lib/sshpm/tasks/remove_user.rb
+++ b/lib/sshpm/tasks/remove_user.rb
@@ -1,5 +1,27 @@
 module SSHPM::Tasks
   class RemoveUser < Dry::Struct
+    constructor_type :strict_with_defaults
+
     attribute :name, Types::Strict::String
+    attribute :delete_home, Types::Strict::Bool.default(false)
+
+    def run_on(host)
+      unless host.is_a? SSHPM::Host
+        raise TypeError("host #{host} is not a #{SSHPM::Host}")
+      end
+
+      options = {
+        password: host.password,
+        port: host.port,
+        paranoid: false
+      }
+
+      Net::SSH.start(host.hostname, host.user, options) do |ssh|
+        flags = ""
+        flags = flags + " -r " if delete_home
+
+        ssh.exec! "userdel #{flags} #{name}"
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ module SSHPM
       ]
     end
 
-    def self.run_docker_container image
+    def self.run_docker_container(image)
       Docker::Container.create(
         'Image' => image,
         'ExposedPorts' => { '22/tcp' => {} },
@@ -25,6 +25,26 @@ module SSHPM
           'PortBindings' => { '22/tcp' => [{}] }
         }
       ).start
+    end
+
+    def self.ssh_password_options(opts={})
+      {
+        password: opts[:password] || 'test_password',
+        port: opts[:port] || '22',
+        non_interactive: opts[:non_interactive] || true,
+        paranoid: opts[:paranoid] || false
+      }
+    end
+
+    def self.ssh_identity_options(opts={})
+      {
+        keys: opts[:keys] || [],
+        key_data: opts[:key_data],
+        keys_only: opts[:keys_only] || true,
+        port: opts[:port] || @port,
+        non_interactive: opts[:non_interactive] || true,
+        paranoid: opts[:paranoid] || false
+      }
     end
   end
 end

--- a/spec/sshpm/manager_spec.rb
+++ b/spec/sshpm/manager_spec.rb
@@ -47,7 +47,6 @@ describe SSHPM::Manager do
       (1..10).each do |index|
         @manager.remove_user do
           name Faker::Internet.user_name
-          password Faker::Internet.password
         end
 
         expect(@manager.tasks.size).to eq(index)

--- a/spec/sshpm_spec.rb
+++ b/spec/sshpm_spec.rb
@@ -68,6 +68,25 @@ describe SSHPM do
               Net::SSH.start('localhost', @user[:username], opts)
             end.to raise_error(Net::SSH::AuthenticationFailed)
           end
+
+          context "Removing user" do
+            before :all do
+              user = @user
+              SSHPM.manage(@host) do
+                remove_user do
+                  name user[:username]
+                  delete_home true
+                end
+              end
+            end
+
+            it "can't login after deletion" do
+              expect do
+                opts = SSHPM::Tests.ssh_password_options port: @port, password: @user[:password]
+                Net::SSH.start('localhost', @user[:username], opts)
+              end.to raise_error(Net::SSH::AuthenticationFailed)
+            end
+          end
         end
 
         context "with only pub/private keys" do
@@ -105,6 +124,25 @@ describe SSHPM do
               opts = SSHPM::Tests.ssh_identity_options port: @port, key_data: [SSHKey.generate.private_key]
               Net::SSH.start('localhost', @user[:username], opts)
             end.to raise_error(Net::SSH::AuthenticationFailed)
+          end
+
+          context "Removing user" do
+            before :all do
+              user = @user
+              SSHPM.manage(@host) do
+                remove_user do
+                  name user[:username]
+                  delete_home true
+                end
+              end
+            end
+
+            it "can't login after deletion" do
+              expect do
+                opts = SSHPM::Tests.ssh_identity_options port: @port, key_data: [@rsa_key.private_key]
+                Net::SSH.start('localhost', @user[:username], opts)
+              end.to raise_error(Net::SSH::AuthenticationFailed)
+            end
           end
         end
 
@@ -160,6 +198,25 @@ describe SSHPM do
             it "using password" do
               expect do
                 opts = SSHPM::Tests.ssh_password_options port: @port, password: Faker::Internet.password
+                Net::SSH.start('localhost', @user[:username], opts)
+              end.to raise_error(Net::SSH::AuthenticationFailed)
+            end
+          end
+
+          context "Removing user" do
+            before :all do
+              user = @user
+              SSHPM.manage(@host) do
+                remove_user do
+                  name user[:username]
+                  delete_home true
+                end
+              end
+            end
+
+            it "can't login after deletion" do
+              expect do
+                opts = SSHPM::Tests.ssh_identity_options port: @port, key_data: [@rsa_key.private_key]
                 Net::SSH.start('localhost', @user[:username], opts)
               end.to raise_error(Net::SSH::AuthenticationFailed)
             end

--- a/spec/sshpm_spec.rb
+++ b/spec/sshpm_spec.rb
@@ -8,7 +8,7 @@ describe SSHPM do
   SSHPM::Tests::Platforms::Docker.each do |platform|
     context "Docker test on #{platform[:name]}" do
       before :all do
-        @container = SSHPM::Tests::run_docker_container platform[:image]
+        @container = SSHPM::Tests.run_docker_container platform[:image]
         @port = @container.json["NetworkSettings"]["Ports"]["22/tcp"].first["HostPort"]
       end
 
@@ -19,26 +19,14 @@ describe SSHPM do
       context "Login as root" do
         it "is successfull if password is correct" do
           expect do
-            opts = {
-              password: 'test_password',
-              port: @port,
-              non_interactive: true,
-              paranoid: false
-            }
-
+            opts = SSHPM::Tests.ssh_password_options port: @port
             Net::SSH.start('localhost', 'root', opts)
           end.to_not raise_error
         end
 
         it "is unsuccessfull if password is incorrect" do
           expect do
-            opts = {
-              password: 'test_passwrd',
-              port: @port,
-              non_interactive: true,
-              paranoid: false
-            }
-
+            opts = SSHPM::Tests.ssh_password_options port: @port, password: 'wrong_password'
             Net::SSH.start('localhost', 'root', opts)
           end.to raise_error(Net::SSH::AuthenticationFailed)
         end
@@ -69,26 +57,14 @@ describe SSHPM do
 
           it "login successfully as the new user on all test servers" do
             expect do
-              opts = {
-                password: @user[:password],
-                port: @port,
-                non_interactive: true,
-                paranoid: false
-              }
-
+              opts = SSHPM::Tests.ssh_password_options port: @port, password: @user[:password]
               Net::SSH.start('localhost', @user[:username], opts)
             end.to_not raise_error
           end
 
           it "login fails if password is wrong" do
             expect do
-              opts = {
-                password: Faker::Internet.password,
-                port: @port,
-                non_interactive: true,
-                paranoid: false
-              }
-              
+              opts = SSHPM::Tests.ssh_password_options port: @port, password: Faker::Internet.password
               Net::SSH.start('localhost', @user[:username], opts)
             end.to raise_error(Net::SSH::AuthenticationFailed)
           end
@@ -119,30 +95,14 @@ describe SSHPM do
 
           it "login successfully as the new user on all test servers" do
             expect do
-              opts = {
-                keys: [],
-                key_data: [@rsa_key.private_key],
-                keys_only: true,
-                port: @port,
-                non_interactive: true,
-                paranoid: false
-              }
-
+              opts = SSHPM::Tests.ssh_identity_options port: @port, key_data: [@rsa_key.private_key]
               Net::SSH.start('localhost', @user[:username], opts)
             end.to_not raise_error
           end
 
           it "login fails if private_key is wrong" do
             expect do
-              opts = {
-                keys: [],
-                key_data: [SSHKey.generate.private_key],
-                keys_only: true,
-                port: @port,
-                non_interactive: true,
-                paranoid: false
-              }
-
+              opts = SSHPM::Tests.ssh_identity_options port: @port, key_data: [SSHKey.generate.private_key]
               Net::SSH.start('localhost', @user[:username], opts)
             end.to raise_error(Net::SSH::AuthenticationFailed)
           end
@@ -176,28 +136,14 @@ describe SSHPM do
           context "login successfully as the new user on all test servers" do
             it "using identity file" do
               expect do
-                opts = {
-                  keys: [],
-                  key_data: [@rsa_key.private_key],
-                  keys_only: true,
-                  port: @port,
-                  non_interactive: true,
-                  paranoid: false
-                }
-
+                opts = SSHPM::Tests.ssh_identity_options port: @port, key_data: [@rsa_key.private_key]
                 Net::SSH.start('localhost', @user[:username], opts)
               end.to_not raise_error
             end
 
             it "using password" do
               expect do
-                opts = {
-                  password: @user[:password],
-                  port: @port,
-                  non_interactive: true,
-                  paranoid: false
-                }
-
+                opts = SSHPM::Tests.ssh_password_options port: @port, password: @user[:password]
                 Net::SSH.start('localhost', @user[:username], opts)
               end.to_not raise_error
             end
@@ -206,28 +152,14 @@ describe SSHPM do
           context "login fails if password or private key is wrong" do
             it "using identity file" do
               expect do
-                opts = {
-                  keys: [],
-                  key_data: [SSHKey.generate.private_key],
-                  keys_only: true,
-                  port: @port,
-                  non_interactive: true,
-                  paranoid: false
-                }
-
+                opts = SSHPM::Tests.ssh_identity_options port: @port, key_data: [SSHKey.generate.private_key]
                 Net::SSH.start('localhost', @user[:username], opts)
               end.to raise_error(Net::SSH::AuthenticationFailed)
             end
 
             it "using password" do
               expect do
-                opts = {
-                  password: Faker::Internet.password,
-                  port: @port,
-                  non_interactive: true,
-                  paranoid: false
-                }
-
+                opts = SSHPM::Tests.ssh_password_options port: @port, password: Faker::Internet.password
                 Net::SSH.start('localhost', @user[:username], opts)
               end.to raise_error(Net::SSH::AuthenticationFailed)
             end


### PR DESCRIPTION
This PR aims to the following syntax:

```ruby
SSHPM.manage(hosts) do
  remove_user do
    name "username"
    delete_home true # default to false
  end
end
```