### PR TITLE
Tasks refactoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'dry-struct'
+gem 'dry-monads'
 gem 'net-ssh'
 
 group :test do

--- a/lib/sshpm.rb
+++ b/lib/sshpm.rb
@@ -1,5 +1,6 @@
 require "net/ssh"
 require "sshpm/version"
+require "sshpm/exceptions"
 require "sshpm/types"
 require "sshpm/manager"
 require "sshpm/entities"

--- a/lib/sshpm/exceptions.rb
+++ b/lib/sshpm/exceptions.rb
@@ -1,0 +1,3 @@
+module SSHPM
+  class NoAuthenticationMethodDefined < Exception; end
+end

--- a/lib/sshpm/tasks.rb
+++ b/lib/sshpm/tasks.rb
@@ -1,3 +1,4 @@
+require 'sshpm/tasks/base_task'
 require 'sshpm/tasks/builder'
 require 'sshpm/tasks/add_user'
 require 'sshpm/tasks/remove_user'

--- a/lib/sshpm/tasks/add_user.rb
+++ b/lib/sshpm/tasks/add_user.rb
@@ -7,11 +7,15 @@ module SSHPM::Tasks
     attribute :public_key, Types::Maybe::Strict::String
     attribute :sudo, Types::Strict::Bool.default(false)
 
-    def run_on(host)
+    def initialize(h)
       super
       if password.none? and public_key.none?
         raise SSHPM::NoAuthenticationMethodDefined
       end
+    end
+
+    def run_on(host)
+      super
 
       options = {
         password: host.password,

--- a/lib/sshpm/tasks/add_user.rb
+++ b/lib/sshpm/tasks/add_user.rb
@@ -1,5 +1,5 @@
 module SSHPM::Tasks
-  class AddUser < Dry::Struct
+  class AddUser < BaseTask
     constructor_type :strict_with_defaults
 
     attribute :name, Types::Strict::String
@@ -8,8 +8,9 @@ module SSHPM::Tasks
     attribute :sudo, Types::Strict::Bool.default(false)
 
     def run_on(host)
-      unless host.is_a? SSHPM::Host
-        raise TypeError("host #{host} is not a #{SSHPM::Host}")
+      super
+      if password == "" and public_key == ""
+        raise SSHPM::NoAuthenticationMethodDefined
       end
 
       options = {

--- a/lib/sshpm/tasks/base_task.rb
+++ b/lib/sshpm/tasks/base_task.rb
@@ -1,0 +1,11 @@
+module SSHPM
+  module Tasks
+    class BaseTask < Dry::Struct
+      def run_on(host)
+        if not host.is_a? SSHPM::Host
+          raise TypeError("host #{host} is not a #{SSHPM::Host}")
+        end
+      end
+    end
+  end
+end

--- a/lib/sshpm/tasks/remove_user.rb
+++ b/lib/sshpm/tasks/remove_user.rb
@@ -1,14 +1,12 @@
 module SSHPM::Tasks
-  class RemoveUser < Dry::Struct
+  class RemoveUser < BaseTask
     constructor_type :strict_with_defaults
 
     attribute :name, Types::Strict::String
     attribute :delete_home, Types::Strict::Bool.default(false)
 
     def run_on(host)
-      unless host.is_a? SSHPM::Host
-        raise TypeError("host #{host} is not a #{SSHPM::Host}")
-      end
+      super
 
       options = {
         password: host.password,

--- a/lib/sshpm/types.rb
+++ b/lib/sshpm/types.rb
@@ -1,5 +1,7 @@
 require 'dry-struct'
 
+Dry::Types.load_extensions :maybe
+
 module Types
   include Dry::Types.module
 end

--- a/spec/sshpm/manager_spec.rb
+++ b/spec/sshpm/manager_spec.rb
@@ -35,6 +35,14 @@ describe SSHPM::Manager do
         expect(task).to be_a(SSHPM::Tasks::AddUser)
       end
     end
+
+    it "Should not create an AddUser task without password or public_key" do
+      expect do
+        @manager.add_user do
+          name Faker::Internet.user_name
+        end
+      end.to raise_error(SSHPM::NoAuthenticationMethodDefined)
+    end
   end
 
   context "remove_user" do


### PR DESCRIPTION
This PR aims to refactor tasks by completing the following points:

- [x] Create a base class with a default `run_on(host)` which contains common function guards for all tasks
- [x] Create a `sshpm/exceptions.rb` file which will contain SSHPM exceptions
  - [x] Create a `SSHP::NoAuthenticationMethodDefined` exception, initially only the `SSHPM::Tasks::AddUser` will make use of this exception
  - [x] Test new exception usage
- [x] Use a `maybe` monad to task attributes which fit this semantics, like `password` and `public_key` for `SSHPM::Tasks::AddUser`